### PR TITLE
Cosmos Explorer: Stake with NeoBase

### DIFF
--- a/src/views/Staking.vue
+++ b/src/views/Staking.vue
@@ -2,7 +2,7 @@
   <div>
     <b-card
       v-if="pingVals && pingVals.length > 0"
-      title="❤️ Helping Ping.pub By Staking ❤️"
+      title="Stake with NeoBase"
       class="overflow-auto"
     >
       <b-table
@@ -308,7 +308,7 @@ export default {
   },
   computed: {
     pingVals() {
-      return this.list.filter(x => x.description.identity === '6783E9F948541962')
+      return this.list.filter(x => x.description.moniker === 'NeoVal')
     },
     list() {
       const tab = this.selectedStatus === 'active' ? this.validators : this.inactiveValidators


### PR DESCRIPTION
link to issue - https://linear.app/neobase/issue/CNF-14

Made it show the `NeoVal` address as our address.
used `description.moniker` to identify NeoVal instead of using `description.identity` as this is what the description object looks like 

![Screenshot 2022-09-23 at 7 21 19 PM](https://user-images.githubusercontent.com/54453857/191976946-0e2edd73-692c-490f-a8e3-7f3f5405a92d.png)

**Haven't looked into giving it an identity and then using that, can do that if that is required instead.**

Note :- ideally the string 'NeoVal' should be stored in an env variable and then used as the variable.
can change it to that if needed, please tell which file to store the env variable in.